### PR TITLE
Set cache headers and enable URL rewrites

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -5,6 +5,17 @@
       "firebase.json",
       "**/.*",
       "**/node_modules/**"
-    ]
+    ],
+    "headers": [{
+      "source": "**/*.@(jpg|jpeg|gif|png|webp|json|js|ico|webm|mp4)",
+      "headers": [{
+        "key": "Cache-Control",
+        "value": "max-age=2592000"
+      }]
+    }],
+    "rewrites": [{
+      "source": "**",
+      "destination": "/index.html"
+    }]
   }
 }


### PR DESCRIPTION
1. Set a longer cache expiration time for static files. 
i.e image and video files.

2. Redirect all paths to index.html. Currently, https://iameirikcom.firebaseapp.com/view3 will not load if you directly go to this URL.